### PR TITLE
feat: "floor(Platform)" are treated like floors when building or digging

### DIFF
--- a/GeneralActions.cs
+++ b/GeneralActions.cs
@@ -277,7 +277,7 @@ static class OnActionComplete
         }
 
         Point targetPoint = GetNextTarget2(
-            cell => AutoAct.IsTarget(cell.sourceFloor) && !cell.HasBlock && !cell.HasObj
+            cell => AutoAct.IsTarget(cell.sourceSurface) && !cell.HasBlock && !cell.HasObj
         );
         if (targetPoint == null)
         {

--- a/TaskBuildActions.cs
+++ b/TaskBuildActions.cs
@@ -24,7 +24,7 @@ static class OnTaskBuildComplete
 		{
 			ContinueBuild(ShouldFertilize, false);
 		}
-		else if (held.category.id == "floor")
+		else if (held.category.id == "floor" || held.category.id == "foundation")
 		{
 			ContinueBuild(p => !p.HasThing && !p.HasBlock && !p.HasObj && p.cell.sourceSurface != AutoAct.startPoint.cell.sourceSurface);
 		}


### PR DESCRIPTION
目前"地板（平台）"的道具與其設置物，不視為"地板"。

這個 patch 更改了以下。

- 如同地板一樣，建造地板（平台）
- 如同地板一樣，挖掘地板（平台）
- fix: 當地板為自動挖掘目標時，不會破壞覆蓋在上方的平台。