### PR TITLE
add brazilian portuguese to langs lang

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -482,6 +482,37 @@ public static class AALang
                 { "startFromCenter", "Start From The Center (Square Only)　　　　 　　　　" },
                 { "sameFarmfieldOnly", "Harvest On The Same Farmfield Only　　　　　　　　" },
             }
+        },
+        {
+            "PTBR", new Dictionary<string, string> {
+                { "autoact", "Ação Automática" },
+                { "settings", "Configurações de Ação Automática" },
+                { "enemyEncounterResponse", "Resposta ao Encontro com Inimigos" },
+                { "eer0", "Parar" },
+                { "eer1", "Ignorar" },
+                { "eer2", "Atacar" },
+                { "detDist", "Distância de Detecção" },
+                { "buildRangeW", "Largura do Alcance de Construção" },
+                { "buildRangeH", "Altura do Alcance de Construção" },
+                { "sowRange", "Alcance de Plantio" },
+                { "pourDepth", "Profundidade de Derramamento" },
+                { "seedReapingCount", "Quantidade para Colheita de Sementes" },
+                { "keyMode", "Modo de Tecla" },
+                { "press", "Pressionar" },
+                { "toggle", "Alternar" },
+                { "start", "Ação Automática iniciada." },
+                { "fail", "Ação Automática foi interrompida." },
+                { "noTarget", "Ação Automática não encontrou o próximo alvo." },
+                { "aaon", "Ação Automática: Ligada." },
+                { "aaoff", "Ação Automática: Desligada." },
+                { "staminaCheck", "Parar Quando a Estamina Acabar" },
+                { "entireFarmfield", "Toda a Área da Fazenda Selecionada" },
+                { "followBuildRange", "Seguir a Área de Construção" },
+                { "simpleIdentify", "Identificação Simples" },
+                { "off", "Desligado" },
+                { "startFromCenter", "Começar pelo Centro (Apenas Quadrados)" },
+                { "sameFarmfieldOnly", "Colher Apenas na Mesma Área da Fazenda" },
+            }
         }
     };
 }


### PR DESCRIPTION
Hey Redgeioz,

How’s it going?

I translated the MOD into Brazilian Portuguese (PTBR) and ran some tests with the language. If a person is subscribed to my complete translation mod for Elin, the mod with the translation will automatically detect and use PTBR. However, if the person isn’t subscribed, it won’t make any difference.

I tested it both with and without the PTBR translation, and it worked correctly. I also tested it both with and without the translation mod installed, and it continued to function perfectly. So, if possible, I kindly ask that you allow this change and upload it to the Steam Workshop.