### PR TITLE
feat: AutoActSmash | Smashing vases and sacks

### DIFF
--- a/Actions/AutoActSmash.cs
+++ b/Actions/AutoActSmash.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+
+namespace AutoActMod.Actions;
+
+public class AutoActSmash : AutoAct
+{
+    public int detRangeSq;
+    public SubActSmash Child => child as SubActSmash;
+    public override Point Pos => Child.pos;
+
+    public AutoActSmash(SubActSmash source) : base(source)
+    {
+        detRangeSq = Settings.DetRangeSq;
+        SetTarget(source.refThing);
+    }
+
+    public static AutoActSmash TryCreate(string lang, Card target, Point pos)
+    {
+        if (EClass.pc.ai is AutoActSmash) { return null; }
+        if (lang != GetActMeleeLang()) { return null; }
+        if (!CanSmash(target)) { return null; }
+        return new AutoActSmash(new SubActSmash(pos, target as Thing));
+    }
+
+    public static bool CanSmash(Card t)
+    {
+        return t.isThing && t.trait.CanBeAttacked && t.trait.CanBeSmashedToDeath && !(t.trait is TraitTrainingDummy);
+    }
+
+    public static string GetActMeleeLang()
+    {
+        return ACT.Melee.source.GetText();
+    }
+
+    public override IEnumerable<Status> Run()
+    {
+        while (CanProgress())
+        {
+            var targetThing = FindThing(CanSmash, detRangeSq);
+            if (targetThing.IsNull())
+            {
+                SayNoTarget();
+                yield break;
+            }
+
+            Child.pos = targetThing.pos;
+            Child.refThing = targetThing;
+            yield return StartNextTask();
+        }
+        yield return FailOrSuccess();
+    }
+
+    public class SubActSmash : AIAct
+    {
+        public Thing refThing;
+        public Point pos;
+
+        public SubActSmash() { }
+        public SubActSmash(Point pos, Thing refThing)
+        {
+            this.pos = pos;
+            this.refThing = refThing;
+        }
+
+        public override IEnumerable<Status> Run()
+        {
+            yield return DoGoto(pos, 1, true);
+
+            if (!CanSmash(refThing) || !ACT.Melee.Perform(owner, refThing))
+            {
+                yield return Cancel();
+            }
+
+            yield return Success();
+        }
+    }
+}


### PR DESCRIPTION
This patch adds an automatic vase (or sack) smashing feature.

Starting from version EA 23.114 Nightly, hero actions like smashing vases and slashing sacks have been added.  
Loot includes Medals (5% chance). 
But that doesn't matter, I'm just want to smash these damn vases.

===

這個 patch 新增了自動砸壺(或是袋子)的功能

版本號 EA 23.114 Nightly 後，新增了砸壺、割布袋的勇者行為
掉落物包含小獎章(5%)
但這不重要，我只是要砸爛這些爛壺
