### PR TITLE
fix: disable AutoActRead for God's Dojin Book

### DIFF
--- a/Actions/AutoActRead.cs
+++ b/Actions/AutoActRead.cs
@@ -40,7 +40,7 @@ public class AutoActRead(AIAct source) : AutoAct(source)
                 break;
             }
 
-            var next = owner.things.Find(t => t.trait is TraitBaseSpellbook && (t.trait is not TraitAncientbook || !t.isOn));
+            var next = owner.things.Find(t => t.trait is TraitBaseSpellbook && (t.trait is not TraitAncientbook || !t.isOn) && t.trait is not TraitUsuihon);
             if (next.HasValue())
             {
                 Child.target = next;


### PR DESCRIPTION
God's Dojin Book is a special item intended for NPC use in the game. It should not be automatically read by the PC when Simple Identification is enabled.

===

神的同人誌在遊戲中是給予 NPC 使用的特殊道具，PC 在簡單辨識開啟時不應該自動閱讀
